### PR TITLE
Variable and expression handling for blade directives

### DIFF
--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -136,7 +136,7 @@ class CacheTags {
 	static public function registerBladeDirectives() {
 
 		Blade::directive('cachetagStart', function ( $params ) {
-			$params = array_map('trim', explode(',', $params));
+			$params = array_map('trim', explode(',', $params, 3));
 			if (count($params) < 1) {
 				throw new InvalidArgumentException(("cachetagStart requires the cache key as a parameter"));
 			}

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -50,7 +50,7 @@ class CacheTags {
 		if ($time !== 'forever') {
 			$time = $time || config('cachetags.timeout', 1);
 		}
-		$tags = static::splitTags($tags | config('cachetags.default_tag', static::class));
+		$tags = static::splitTags($tags ?: config('cachetags.default_tag', static::class));
 
 		if ($time === null) {
 			$time = 15;
@@ -174,7 +174,7 @@ class CacheTags {
 	 */
 	public function get( $key, $tags = '' ) {
 		if ($this->cache->supportsTags()) {
-			$tags    = static::splitTags($tags | config('cachetags.default_tag', static::class));
+			$tags    = static::splitTags($tags ?: config('cachetags.default_tag', static::class));
 			$content = $this->cache->tags($tags)->get($key);
 		} else {
 			$content = $this->cache->get($key);
@@ -191,7 +191,7 @@ class CacheTags {
 	 */
 	public function clear( $key, $tags = '' ) {
 		if ($this->cache->supportsTags()) {
-			$tags = static::splitTags($tags | config('cachetags.default_tag', static::class));
+			$tags = static::splitTags($tags ?: config('cachetags.default_tag', static::class));
 			$this->cache->tags($tags)->flush($key);
 		} else {
 			$this->cache->forget($key);

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -42,9 +42,9 @@ class CacheTags {
 	/**
 	 * Start caching the output that follows this call
 	 *
-	 * @param        $key
-	 * @param null   $time
-	 * @param string $tags
+	 * @param              $key
+	 * @param null         $time
+	 * @param array|string $tags
 	 */
 	public function start( $key, $time = null, $tags = '' ) {
 		if ($time !== 'forever') {
@@ -136,19 +136,19 @@ class CacheTags {
 	static public function registerBladeDirectives() {
 
 		Blade::directive('cachetagStart', function ( $params ) {
-			$params = array_map('trim', explode(',', $params), [' "\'']);
+			$params = array_map('trim', explode(',', $params));
 			if (count($params) < 1) {
 				throw new InvalidArgumentException(("cachetagStart requires the cache key as a parameter"));
 			}
 			$key  = $params[0];
 			$time = isset($params[1]) ? $params[1] : config('cachetags.timeout', 15);
-			$tag  = isset($params[2]) ? $params[2] : 'cachetags';
+			$tag  = isset($params[2]) ? $params[2] : '"cachetags"';
 
 			return "<?php
-			if ( cachetagHas(\"{$key}\") ){
-				echo cachetagGet(\"{$key}\");
+			if ( cachetagHas({$key}) ){
+				echo cachetagGet({$key});
 			} else {
-				cachetagStart(\"{$key}\", $time, \"{$tag}\");
+				cachetagStart({$key}, $time, {$tag});
 			?>";
 		});
 
@@ -167,8 +167,8 @@ class CacheTags {
 	/**
 	 * Retrieve a cached item
 	 *
-	 * @param        $key
-	 * @param string $tags
+	 * @param              $key
+	 * @param array|string $tags
 	 *
 	 * @return mixed
 	 */
@@ -186,8 +186,8 @@ class CacheTags {
 	/**
 	 * Clear a cached item
 	 *
-	 * @param        $key
-	 * @param string $tags
+	 * @param              $key
+	 * @param array|string $tags
 	 */
 	public function clear( $key, $tags = '' ) {
 		if ($this->cache->supportsTags()) {
@@ -201,7 +201,7 @@ class CacheTags {
 	/**
 	 * get a tag array from the supplied string
 	 *
-	 * @param $tags
+	 * @param array|string $tags
 	 *
 	 * @return array
 	 */

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -42,9 +42,9 @@ class CacheTags {
 	/**
 	 * Start caching the output that follows this call
 	 *
-	 * @param              $key
-	 * @param null         $time
-	 * @param array|string $tags
+	 * @param                      $key
+	 * @param null                 $time
+	 * @param array|string|Closure $tags
 	 */
 	public function start( $key, $time = null, $tags = '' ) {
 		if ($time !== 'forever') {
@@ -167,8 +167,8 @@ class CacheTags {
 	/**
 	 * Retrieve a cached item
 	 *
-	 * @param              $key
-	 * @param array|string $tags
+	 * @param                      $key
+	 * @param array|string|Closure $tags
 	 *
 	 * @return mixed
 	 */
@@ -186,8 +186,8 @@ class CacheTags {
 	/**
 	 * Clear a cached item
 	 *
-	 * @param              $key
-	 * @param array|string $tags
+	 * @param                      $key
+	 * @param array|string|Closure $tags
 	 */
 	public function clear( $key, $tags = '' ) {
 		if ($this->cache->supportsTags()) {
@@ -199,13 +199,14 @@ class CacheTags {
 	}
 
 	/**
-	 * get a tag array from the supplied string
+	 * get a tag array from the supplied string or closure
 	 *
-	 * @param array|string $tags
+	 * @param array|string|Closure $tags
 	 *
 	 * @return array
 	 */
 	static public function splitTags( $tags ) {
+		$tags = value($tags);
 		$result = $tags;
 		if ( !is_array($tags)) {
 			$result = explode(',', (string) $tags);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,9 +11,9 @@ use Perturbatio\CacheTags\CacheTags;
 
 if ( !function_exists('cachetagStart')) {
 	/**
-	 * @param              $key
-	 * @param              $time
-	 * @param array|string $tag
+	 * @param                      $key
+	 * @param                      $time
+	 * @param array|string|Closure $tag
 	 */
 	function cachetagStart( $key, $time = null, $tag = '' ) {
 		app('CacheTags')->start($key, $time, $tag);
@@ -41,8 +41,8 @@ if ( !function_exists('cachetagHas')) {
 }
 if ( !function_exists('cachetagClear')) {
 	/**
-	 * @param              $key
-	 * @param array|string $tag
+	 * @param                      $key
+	 * @param array|string|Closure $tag
 	 *
 	 * @return mixed
 	 */
@@ -53,8 +53,8 @@ if ( !function_exists('cachetagClear')) {
 
 if ( !function_exists('cachetagGet')) {
 	/**
-	 * @param              $key
-	 * @param array|string $tag
+	 * @param                      $key
+	 * @param array|string|Closure $tag
 	 *
 	 * @return mixed
 	 */

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,9 +11,9 @@ use Perturbatio\CacheTags\CacheTags;
 
 if ( !function_exists('cachetagStart')) {
 	/**
-	 * @param        $key
-	 * @param        $time
-	 * @param string $tag
+	 * @param              $key
+	 * @param              $time
+	 * @param array|string $tag
 	 */
 	function cachetagStart( $key, $time = null, $tag = '' ) {
 		app('CacheTags')->start($key, $time, $tag);
@@ -41,7 +41,8 @@ if ( !function_exists('cachetagHas')) {
 }
 if ( !function_exists('cachetagClear')) {
 	/**
-	 * @param $key
+	 * @param              $key
+	 * @param array|string $tag
 	 *
 	 * @return mixed
 	 */
@@ -52,7 +53,8 @@ if ( !function_exists('cachetagClear')) {
 
 if ( !function_exists('cachetagGet')) {
 	/**
-	 * @param $key
+	 * @param              $key
+	 * @param array|string $tag
 	 *
 	 * @return mixed
 	 */


### PR DESCRIPTION
1. These changes allow not only to supply scalar values to the blade directives of this package, but also variables and expressions from the parent context, e.g. `@cachetagStart($cacheKey ?? 'fallbackCacheKey', 30)`.
2. It is now possible to supply a Closure to the directives (and the underlying methods) that only retrieves the cache tags if they are needed; reducing the performance hit of complicated cache tag calculation on a cache hit (which actually doesn't use the cache tags). Example: `@cachetagStart($cacheKey, 15, static fn () => ($user = Auth::user())->relatedContacts->map->cacheTag->merge($user->cacheTag)->values()->all())`
I also updated the PHPDoc comments to reflect the already existing behavior that you could pass an array of cache tags to the respective functions.
4. I replaced the uses of the bitwise "or" operator with the shorthand ternary operator ?: because the "or" operator caused type errors with these changes