### PR TITLE
use tags to check cache entry existence and retrieve entry

### DIFF
--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -69,12 +69,18 @@ class CacheTags {
 	/**
 	 * Determine if the cache has the specified key
 	 *
-	 * @param $key
+	 * @param                      $key
+	 * @param array|string|Closure $tags
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
-	public function has( $key ) {
-		return $this->cache->has($key);
+	public function has( $key, $tags = '' ) {
+		if ($this->cache->supportsTags()) {
+			$tags    = static::splitTags($tags ?: config('cachetags.default_tag', static::class));
+			return $this->cache->tags($tags)->has($key);
+		} else {
+			return $this->cache->has($key);
+		}
 	}
 
 	/**
@@ -145,8 +151,8 @@ class CacheTags {
 			$tag  = isset($params[2]) ? $params[2] : '"cachetags"';
 
 			return "<?php
-			if ( cachetagHas({$key}) ){
-				echo cachetagGet({$key});
+			if ( cachetagHas({$key}, {$tag}) ){
+				echo cachetagGet({$key}, {$tag});
 			} else {
 				cachetagStart({$key}, $time, {$tag});
 			?>";

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -31,12 +31,13 @@ if ( !function_exists('cachetagEnd')) {
 
 if ( !function_exists('cachetagHas')) {
 	/**
-	 * @param $key
+	 * @param                      $key
+	 * @param array|string|Closure $tag
 	 *
 	 * @return mixed
 	 */
-	function cachetagHas( $key ) {
-		return app('CacheTags')->has($key);
+	function cachetagHas( $key, $tag = '' ) {
+		return app('CacheTags')->has($key, $tag);
 	}
 }
 if ( !function_exists('cachetagClear')) {

--- a/tests/CacheTagsTest.php
+++ b/tests/CacheTagsTest.php
@@ -55,6 +55,15 @@ class CacheTagsTest extends \Orchestra\Testbench\TestCase {
 		$this->assertEquals($testValue, $this->cacheTags->get($cacheKey), " data was not cached");
 	}
 
+	public function testCachedDataExistenceCheck() {
+		$testValue = __METHOD__ . ':value';
+		$cacheKey  = __METHOD__;
+		$this->cacheTags->start($cacheKey, 1, 'testTag');
+		echo $testValue;
+		$this->cacheTags->end();
+		$this->assertTrue($this->cacheTags->has($cacheKey, 'testTag'), " cached data existence check failed");
+	}
+
 	public function testIfCachedDataCanBeTagged() {
 		$testValue = __METHOD__ . ':value';
 		$cacheKey  = __METHOD__;


### PR DESCRIPTION
Currently the tags are used to write the entries, but not to check their existence or, when using the blade directive, to retrieve them.
Since cache entries written using cache tags are not retrievable without those tags, this led to the cache retrieval not working correctly.

(I found this because the cache context duplicate check failed when using the same view twice inside a single page, although the cacheTagStart block is not supposed to be entered with a correctly working cacheTagHas check)